### PR TITLE
feat: add content AI agent extension and demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Have a look at the [examples to see Tiptap in action](https://tiptap.dev/example
 - [Basic example of the Tiptap editor.](https://codesandbox.io/p/devbox/editor-9x9dkd?embed=1&file=%2Fsrc%2FApp.js)
 - [Collaboration ready Tiptap CodeSandbox](https://codesandbox.io/p/devbox/collaboration-4stk94)
 - React notion-like block editor template: [Demo](https://templates.tiptap.dev/)
+- [Content AI Agent React Demo](./demos/content-ai-agent)
 
 ## About Tiptap
 

--- a/demos/content-ai-agent/index.html
+++ b/demos/content-ai-agent/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Content AI Agent Demo</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/demos/content-ai-agent/package.json
+++ b/demos/content-ai-agent/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "content-ai-agent-demo",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "lint": "prettier ./src --check && eslint --cache --quiet ./src"
+  },
+  "dependencies": {
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "@tiptap/react": "workspace:^",
+    "@tiptap/extension-starter-kit": "workspace:^",
+    "@tiptap/extension-content-ai-agent": "workspace:^"
+  },
+  "devDependencies": {
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "@vitejs/plugin-react": "^1.3.2",
+    "typescript": "^5.7.3",
+    "vite": "^5.4.17"
+  }
+}

--- a/demos/content-ai-agent/package.json
+++ b/demos/content-ai-agent/package.json
@@ -10,7 +10,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "@tiptap/react": "workspace:^",
-    "@tiptap/extension-starter-kit": "workspace:^",
+    "@tiptap/starter-kit": "workspace:^",
     "@tiptap/extension-content-ai-agent": "workspace:^"
   },
   "devDependencies": {

--- a/demos/content-ai-agent/src/App.tsx
+++ b/demos/content-ai-agent/src/App.tsx
@@ -1,6 +1,8 @@
+import './styles.css'
+
 import ContentAiAgent from '@tiptap/extension-content-ai-agent'
-import StarterKit from '@tiptap/extension-starter-kit'
 import { EditorContent, useEditor } from '@tiptap/react'
+import StarterKit from '@tiptap/starter-kit'
 import type { Diff } from 'diff-match-patch'
 import React, { useState } from 'react'
 
@@ -42,20 +44,45 @@ export default function App() {
   }
 
   return (
-    <div style={{ display: 'flex', gap: '1rem' }}>
+    <div className="editor-container">
       <aside>
+        <h3>AI Recipes</h3>
         {recipes.map(r => (
           <button key={r.prompt} onClick={() => run(r.prompt)}>
             {r.label}
           </button>
         ))}
       </aside>
-      <div style={{ flex: 1 }}>
+      <div className="editor-wrapper">
+        <h3>Editor</h3>
         <EditorContent editor={editor} />
       </div>
       {diffState && (
-        <div>
-          <pre>{diffState.diff.map(part => part[1]).join('')}</pre>
+        <div className="diff-panel">
+          <h3>AI Suggestion</h3>
+          <pre style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
+            {diffState.diff.map((part, i) => {
+              const [operation, text] = part
+              if (operation === 0) {
+                // Unchanged text
+                return <span key={i}>{text}</span>
+              } if (operation === -1) {
+                // Deleted text (original)
+                return (
+                  <span key={i} style={{ backgroundColor: '#ffcccc', textDecoration: 'line-through' }}>
+                    {text}
+                  </span>
+                )
+              } 
+                // Added text (new)
+                return (
+                  <span key={i} style={{ backgroundColor: '#ccffcc' }}>
+                    {text}
+                  </span>
+                )
+              
+            })}
+          </pre>
           <button onClick={diffState.accept}>Accept</button>
           <button onClick={diffState.reject}>Reject</button>
         </div>

--- a/demos/content-ai-agent/src/App.tsx
+++ b/demos/content-ai-agent/src/App.tsx
@@ -1,0 +1,65 @@
+import ContentAiAgent from '@tiptap/extension-content-ai-agent'
+import StarterKit from '@tiptap/extension-starter-kit'
+import { EditorContent, useEditor } from '@tiptap/react'
+import type { Diff } from 'diff-match-patch'
+import React, { useState } from 'react'
+
+interface DiffState {
+  diff: Diff[]
+  accept: () => void
+  reject: () => void
+}
+
+const recipes = [
+  { label: 'Reverse', prompt: 'reverse' },
+  { label: 'Uppercase', prompt: 'uppercase' },
+]
+
+export default function App() {
+  const [diffState, setDiffState] = useState<DiffState | null>(null)
+
+  const editor = useEditor({
+    extensions: [
+      StarterKit,
+      ContentAiAgent.configure({
+        runAgent: async ({ text, prompt }) => {
+          if (prompt === 'reverse') {
+            return text.split('').reverse().join('')
+          }
+          return text.toUpperCase()
+        },
+        onDiffReady: payload => {
+          setDiffState(payload)
+        },
+      }),
+    ],
+    content: '<p>Select text and run a recipe.</p>',
+  })
+
+  const run = (prompt: string) => {
+    setDiffState(null)
+    editor?.chain().focus().runContentAiAgent({ prompt }).run()
+  }
+
+  return (
+    <div style={{ display: 'flex', gap: '1rem' }}>
+      <aside>
+        {recipes.map(r => (
+          <button key={r.prompt} onClick={() => run(r.prompt)}>
+            {r.label}
+          </button>
+        ))}
+      </aside>
+      <div style={{ flex: 1 }}>
+        <EditorContent editor={editor} />
+      </div>
+      {diffState && (
+        <div>
+          <pre>{diffState.diff.map(part => part[1]).join('')}</pre>
+          <button onClick={diffState.accept}>Accept</button>
+          <button onClick={diffState.reject}>Reject</button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/demos/content-ai-agent/src/main.tsx
+++ b/demos/content-ai-agent/src/main.tsx
@@ -2,9 +2,19 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 
 import App from './App.js'
+// import SimpleApp from './SimpleApp.js'
 
-ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+const root = document.getElementById('root')
+if (!root) {
+  throw new Error('Root element not found')
+}
+
+ReactDOM.createRoot(root).render(
   <React.StrictMode>
-    <App />
+    <div>
+      <h1>TipTap Content AI Agent Demo</h1>
+      <p>Select some text in the editor and click a recipe button to see AI transformations with diff preview.</p>
+      <App />
+    </div>
   </React.StrictMode>,
 )

--- a/demos/content-ai-agent/src/main.tsx
+++ b/demos/content-ai-agent/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+
+import App from './App.js'
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+)

--- a/demos/content-ai-agent/src/styles.css
+++ b/demos/content-ai-agent/src/styles.css
@@ -1,0 +1,92 @@
+body {
+  margin: 0;
+  padding: 20px;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', sans-serif;
+}
+
+.editor-container {
+  display: flex;
+  gap: 1rem;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+aside {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  min-width: 150px;
+}
+
+button {
+  padding: 8px 16px;
+  background: #007bff;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 14px;
+}
+
+button:hover {
+  background: #0056b3;
+}
+
+.editor-wrapper {
+  flex: 1;
+}
+
+.ProseMirror {
+  border: 2px solid #ddd;
+  border-radius: 4px;
+  padding: 12px;
+  min-height: 200px;
+  outline: none;
+}
+
+.ProseMirror:focus {
+  border-color: #007bff;
+}
+
+.ProseMirror p {
+  margin: 0 0 1em 0;
+}
+
+.ProseMirror p:last-child {
+  margin-bottom: 0;
+}
+
+.diff-panel {
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  padding: 12px;
+  background: #f8f9fa;
+}
+
+.diff-panel pre {
+  margin: 0 0 1em 0;
+  padding: 8px;
+  background: white;
+  border-radius: 4px;
+  overflow-x: auto;
+}
+
+.diff-panel button {
+  margin-right: 8px;
+}
+
+.content-ai-agent-pending {
+  background-color: #fffbdd;
+  border-bottom: 2px dashed #ffc107;
+}
+
+.content-ai-agent-spinner {
+  display: inline-block;
+  color: #007bff;
+  animation: pulse 1.5s ease-in-out infinite;
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.5; }
+}

--- a/demos/content-ai-agent/tsconfig.json
+++ b/demos/content-ai-agent/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true
+  },
+  "include": ["src"]
+}

--- a/demos/content-ai-agent/vite.config.ts
+++ b/demos/content-ai-agent/vite.config.ts
@@ -1,0 +1,6 @@
+import react from '@vitejs/plugin-react'
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  plugins: [react()],
+})

--- a/demos/content-ai-agent/vite.config.ts
+++ b/demos/content-ai-agent/vite.config.ts
@@ -1,6 +1,42 @@
 import react from '@vitejs/plugin-react'
+import path from 'path'
 import { defineConfig } from 'vite'
 
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      '@tiptap/core/jsx-runtime': path.resolve(__dirname, '../../packages/core/dist/jsx-runtime/jsx-runtime.js'),
+    },
+  },
+  optimizeDeps: {
+    include: [
+      '@tiptap/core',
+      '@tiptap/react',
+      '@tiptap/starter-kit',
+      '@tiptap/extension-content-ai-agent',
+      '@tiptap/pm/state',
+      '@tiptap/pm/view',
+      '@tiptap/pm/model',
+      '@tiptap/pm/transform',
+      '@tiptap/pm/commands',
+      '@tiptap/pm/keymap',
+      '@tiptap/pm/history',
+      '@tiptap/pm/inputrules',
+      '@tiptap/pm/gapcursor',
+      '@tiptap/pm/dropcursor',
+      '@tiptap/pm/schema-basic',
+      '@tiptap/pm/schema-list',
+      'diff-match-patch',
+    ],
+    esbuildOptions: {
+      define: {
+        global: 'globalThis',
+      },
+    },
+  },
+  define: {
+    'process.env': {},
+    global: 'globalThis',
+  },
 })

--- a/packages/extension-content-ai-agent/CHANGELOG.md
+++ b/packages/extension-content-ai-agent/CHANGELOG.md
@@ -1,0 +1,5 @@
+# @tiptap/extension-content-ai-agent
+
+## 0.0.0
+
+- Initial release.

--- a/packages/extension-content-ai-agent/README.md
+++ b/packages/extension-content-ai-agent/README.md
@@ -1,0 +1,45 @@
+# @tiptap/extension-content-ai-agent
+
+Content AI Agent extension for [Tiptap](https://tiptap.dev).
+
+## Usage
+
+```ts
+import { Editor } from '@tiptap/core'
+import StarterKit from '@tiptap/extension-starter-kit'
+import ContentAiAgent from '@tiptap/extension-content-ai-agent'
+
+const editor = new Editor({
+  extensions: [
+    StarterKit,
+    ContentAiAgent.configure({
+      runAgent: async ({ text }) => {
+        // send `text` to your AI service
+        return text.toUpperCase()
+      },
+      onDiffReady: ({ diff, accept, reject }) => {
+        // render diff in your UI and call accept() or reject()
+      },
+    }),
+  ],
+})
+```
+
+### Options
+
+- `runAgent`: `(args) => Promise<string>` – required function that returns the generated content.
+- `onStart`: called before `runAgent` is executed.
+- `onDiffReady`: called with diff information and `accept`/`reject` callbacks.
+- `onSuccess`: called when the diff was accepted and content inserted.
+- `onReject`: called when the diff was rejected.
+- `onError`: called when `runAgent` rejects.
+
+### Demo
+
+A demo showcasing this extension can be found in [`demos/content-ai-agent`](../../demos/content-ai-agent).
+
+Run it with:
+
+```bash
+pnpm --filter content-ai-agent-demo dev
+```

--- a/packages/extension-content-ai-agent/package.json
+++ b/packages/extension-content-ai-agent/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "@tiptap/extension-content-ai-agent",
+  "description": "content ai agent extension for tiptap",
+  "version": "0.0.0",
+  "homepage": "https://tiptap.dev",
+  "keywords": ["tiptap", "tiptap extension", "ai"],
+  "license": "MIT",
+  "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/ueberdosis"
+  },
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": {
+        "import": "./dist/index.d.ts",
+        "require": "./dist/index.d.cts"
+      },
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": ["src", "dist"],
+  "devDependencies": {
+    "@tiptap/core": "workspace:^",
+    "diff-match-patch": "^1.0.5"
+  },
+  "peerDependencies": {
+    "@tiptap/core": "workspace:^"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ueberdosis/tiptap",
+    "directory": "packages/extension-content-ai-agent"
+  },
+  "scripts": {
+    "build": "tsup",
+    "lint": "prettier ./src/ --check && eslint --cache --quiet --no-error-on-unmatched-pattern ./src/"
+  }
+}

--- a/packages/extension-content-ai-agent/package.json
+++ b/packages/extension-content-ai-agent/package.json
@@ -3,7 +3,11 @@
   "description": "content ai agent extension for tiptap",
   "version": "0.0.0",
   "homepage": "https://tiptap.dev",
-  "keywords": ["tiptap", "tiptap extension", "ai"],
+  "keywords": [
+    "tiptap",
+    "tiptap extension",
+    "ai"
+  ],
   "license": "MIT",
   "funding": {
     "type": "github",
@@ -23,13 +27,19 @@
   "main": "dist/index.cjs",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",
-  "files": ["src", "dist"],
+  "files": [
+    "src",
+    "dist"
+  ],
   "devDependencies": {
     "@tiptap/core": "workspace:^",
+    "@tiptap/pm": "workspace:^",
+    "@types/diff-match-patch": "^1.0.36",
     "diff-match-patch": "^1.0.5"
   },
   "peerDependencies": {
-    "@tiptap/core": "workspace:^"
+    "@tiptap/core": "workspace:^",
+    "@tiptap/pm": "workspace:^"
   },
   "repository": {
     "type": "git",

--- a/packages/extension-content-ai-agent/src/content-ai-agent.ts
+++ b/packages/extension-content-ai-agent/src/content-ai-agent.ts
@@ -1,7 +1,8 @@
 import { type Editor, Extension } from '@tiptap/core'
 import { Plugin, PluginKey } from '@tiptap/pm/state'
 import { Decoration, DecorationSet } from '@tiptap/pm/view'
-import DiffMatchPatch, { type Diff } from 'diff-match-patch'
+import type { Diff } from 'diff-match-patch'
+import DiffMatchPatch from 'diff-match-patch'
 
 export interface ContentAiAgentOptions {
   runAgent: (options: { editor: Editor; text: string; from: number; to: number; prompt?: string }) => Promise<string>
@@ -25,6 +26,18 @@ interface PendingRequest {
   to: number
 }
 
+declare module '@tiptap/core' {
+  interface Commands<ReturnType> {
+    contentAiAgent: {
+      /**
+       * Run the Content AI agent on selected text
+       * @example editor.commands.runContentAiAgent({ prompt: 'uppercase' })
+       */
+      runContentAiAgent: (options?: { prompt?: string }) => ReturnType
+    }
+  }
+}
+
 const pluginKey = new PluginKey<{ pending: PendingRequest[] }>('content-ai-agent')
 
 export const ContentAiAgent = Extension.create<ContentAiAgentOptions>({
@@ -39,8 +52,8 @@ export const ContentAiAgent = Extension.create<ContentAiAgentOptions>({
   addCommands() {
     return {
       runContentAiAgent:
-        options =>
-        ({ editor }) => {
+        (options?: { prompt?: string }) =>
+        ({ editor }: { editor: Editor }) => {
           const { state, view } = editor
           const { from, to } = state.selection
           const text = state.doc.textBetween(from, to, ' ')
@@ -89,16 +102,16 @@ export const ContentAiAgent = Extension.create<ContentAiAgentOptions>({
         key: pluginKey,
         state: {
           init: () => ({ pending: [] }),
-          apply: (tr, value) => {
+          apply: (tr: any, value: any) => {
             let pending = value.pending
             const meta = tr.getMeta(pluginKey)
             if (meta?.type === 'add') {
               pending = [...pending, { id: meta.id, from: meta.from, to: meta.to }]
             } else if (meta?.type === 'remove') {
-              pending = pending.filter(p => p.id !== meta.id)
+              pending = pending.filter((p: any) => p.id !== meta.id)
             }
             if (tr.docChanged) {
-              pending = pending.map(p => ({
+              pending = pending.map((p: any) => ({
                 id: p.id,
                 from: tr.mapping.map(p.from),
                 to: tr.mapping.map(p.to),
@@ -108,13 +121,13 @@ export const ContentAiAgent = Extension.create<ContentAiAgentOptions>({
           },
         },
         props: {
-          decorations: state => {
+          decorations: (state: any) => {
             const pluginState = pluginKey.getState(state)
             if (!pluginState || pluginState.pending.length === 0) {
               return null
             }
             const decorations: Decoration[] = []
-            pluginState.pending.forEach(({ from, to }) => {
+            pluginState.pending.forEach(({ from, to }: { from: number; to: number }) => {
               decorations.push(Decoration.inline(from, to, { class: 'content-ai-agent-pending' }))
               decorations.push(
                 Decoration.widget(to, () => {

--- a/packages/extension-content-ai-agent/src/content-ai-agent.ts
+++ b/packages/extension-content-ai-agent/src/content-ai-agent.ts
@@ -1,0 +1,136 @@
+import { type Editor, Extension } from '@tiptap/core'
+import { Plugin, PluginKey } from '@tiptap/pm/state'
+import { Decoration, DecorationSet } from '@tiptap/pm/view'
+import DiffMatchPatch, { type Diff } from 'diff-match-patch'
+
+export interface ContentAiAgentOptions {
+  runAgent: (options: { editor: Editor; text: string; from: number; to: number; prompt?: string }) => Promise<string>
+  onStart?: (options: { editor: Editor; text: string; from: number; to: number; prompt?: string }) => void
+  onDiffReady?: (options: {
+    editor: Editor
+    diff: Diff[]
+    original: string
+    generated: string
+    accept: () => void
+    reject: () => void
+  }) => void
+  onSuccess?: (options: { editor: Editor; from: number; to: number; text: string }) => void
+  onReject?: (options: { editor: Editor; from: number; to: number; text: string }) => void
+  onError?: (options: { editor: Editor; error: unknown }) => void
+}
+
+interface PendingRequest {
+  id: string
+  from: number
+  to: number
+}
+
+const pluginKey = new PluginKey<{ pending: PendingRequest[] }>('content-ai-agent')
+
+export const ContentAiAgent = Extension.create<ContentAiAgentOptions>({
+  name: 'contentAiAgent',
+
+  addOptions() {
+    return {
+      runAgent: ({ text }) => Promise.resolve(text),
+    }
+  },
+
+  addCommands() {
+    return {
+      runContentAiAgent:
+        options =>
+        ({ editor }) => {
+          const { state, view } = editor
+          const { from, to } = state.selection
+          const text = state.doc.textBetween(from, to, ' ')
+          const id = `ai-${Date.now()}`
+
+          this.options.onStart?.({ editor, text, from, to, prompt: options?.prompt })
+
+          const tr = state.tr.setMeta(pluginKey, { type: 'add', id, from, to })
+          view.dispatch(tr)
+
+          this.options
+            .runAgent({ editor, text, from, to, prompt: options?.prompt })
+            .then(generated => {
+              const dmp = new DiffMatchPatch()
+              const diff = dmp.diff_main(text, generated)
+              dmp.diff_cleanupSemantic(diff)
+
+              const accept = () => {
+                const insertTr = editor.state.tr
+                  .insertText(generated, from, to)
+                  .setMeta(pluginKey, { type: 'remove', id })
+                editor.view.dispatch(insertTr)
+                this.options.onSuccess?.({ editor, from, to: from + generated.length, text: generated })
+              }
+
+              const reject = () => {
+                editor.view.dispatch(editor.state.tr.setMeta(pluginKey, { type: 'remove', id }))
+                this.options.onReject?.({ editor, from, to, text })
+              }
+
+              this.options.onDiffReady?.({ editor, diff, original: text, generated, accept, reject })
+            })
+            .catch(error => {
+              editor.view.dispatch(editor.state.tr.setMeta(pluginKey, { type: 'remove', id }))
+              this.options.onError?.({ editor, error })
+            })
+
+          return true
+        },
+    }
+  },
+
+  addProseMirrorPlugins() {
+    return [
+      new Plugin<{ pending: PendingRequest[] }>({
+        key: pluginKey,
+        state: {
+          init: () => ({ pending: [] }),
+          apply: (tr, value) => {
+            let pending = value.pending
+            const meta = tr.getMeta(pluginKey)
+            if (meta?.type === 'add') {
+              pending = [...pending, { id: meta.id, from: meta.from, to: meta.to }]
+            } else if (meta?.type === 'remove') {
+              pending = pending.filter(p => p.id !== meta.id)
+            }
+            if (tr.docChanged) {
+              pending = pending.map(p => ({
+                id: p.id,
+                from: tr.mapping.map(p.from),
+                to: tr.mapping.map(p.to),
+              }))
+            }
+            return { pending }
+          },
+        },
+        props: {
+          decorations: state => {
+            const pluginState = pluginKey.getState(state)
+            if (!pluginState || pluginState.pending.length === 0) {
+              return null
+            }
+            const decorations: Decoration[] = []
+            pluginState.pending.forEach(({ from, to }) => {
+              decorations.push(Decoration.inline(from, to, { class: 'content-ai-agent-pending' }))
+              decorations.push(
+                Decoration.widget(to, () => {
+                  const span = document.createElement('span')
+                  span.className = 'content-ai-agent-spinner'
+                  span.textContent = '…'
+                  return span
+                }),
+              )
+            })
+            return DecorationSet.create(state.doc, decorations)
+          },
+        },
+      }),
+    ]
+  },
+})
+
+export default ContentAiAgent

--- a/packages/extension-content-ai-agent/src/index.ts
+++ b/packages/extension-content-ai-agent/src/index.ts
@@ -1,0 +1,5 @@
+import { ContentAiAgent } from './content-ai-agent.js'
+
+export * from './content-ai-agent.js'
+
+export default ContentAiAgent

--- a/packages/extension-content-ai-agent/tsup.config.ts
+++ b/packages/extension-content-ai-agent/tsup.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  tsconfig: '../../tsconfig.build.json',
+  outDir: 'dist',
+  dts: true,
+  clean: true,
+  sourcemap: true,
+  format: ['esm', 'cjs'],
+})

--- a/packages/extension-content-ai-agent/tsup.config.ts
+++ b/packages/extension-content-ai-agent/tsup.config.ts
@@ -8,4 +8,5 @@ export default defineConfig({
   clean: true,
   sourcemap: true,
   format: ['esm', 'cjs'],
+  external: ['@tiptap/core', '@tiptap/pm/state', '@tiptap/pm/view', 'diff-match-patch'],
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -309,6 +309,40 @@ importers:
         specifier: ^4.5.0
         version: 4.5.0(vue@3.5.13(typescript@5.7.3))
 
+  demos/content-ai-agent:
+    dependencies:
+      '@tiptap/extension-content-ai-agent':
+        specifier: workspace:^
+        version: link:../../packages/extension-content-ai-agent
+      '@tiptap/react':
+        specifier: workspace:^
+        version: link:../../packages/react
+      '@tiptap/starter-kit':
+        specifier: workspace:^
+        version: link:../../packages/starter-kit
+      react:
+        specifier: ^19.0.0
+        version: 19.1.0
+      react-dom:
+        specifier: ^19.0.0
+        version: 19.1.0(react@19.1.0)
+    devDependencies:
+      '@types/react':
+        specifier: ^19.0.0
+        version: 19.1.6
+      '@types/react-dom':
+        specifier: ^19.0.0
+        version: 19.1.5(@types/react@19.1.6)
+      '@vitejs/plugin-react':
+        specifier: ^1.3.2
+        version: 1.3.2
+      typescript:
+        specifier: ^5.7.3
+        version: 5.7.3
+      vite:
+        specifier: ^5.4.17
+        version: 5.4.18(@types/node@22.10.3)(sass@1.83.4)(terser@5.37.0)
+
   packages-deprecated/extension-character-count:
     devDependencies:
       '@tiptap/extensions':
@@ -491,6 +525,21 @@ importers:
       '@tiptap/extension-text-style':
         specifier: workspace:^
         version: link:../extension-text-style
+
+  packages/extension-content-ai-agent:
+    devDependencies:
+      '@tiptap/core':
+        specifier: workspace:^
+        version: link:../core
+      '@tiptap/pm':
+        specifier: workspace:^
+        version: link:../pm
+      '@types/diff-match-patch':
+        specifier: ^1.0.36
+        version: 1.0.36
+      diff-match-patch:
+        specifier: ^1.0.5
+        version: 1.0.5
 
   packages/extension-details:
     devDependencies:
@@ -2958,6 +3007,9 @@ packages:
   '@types/conventional-commits-parser@5.0.1':
     resolution: {integrity: sha512-7uz5EHdzz2TqoMfV7ee61Egf5y6NkcO4FB/1iCCQnbeiI1F3xzv3vK5dBCXUCLQgGYS+mUeigK1iKQzvED+QnQ==}
 
+  '@types/diff-match-patch@1.0.36':
+    resolution: {integrity: sha512-xFdR6tkm0MWvBfO8xXCSsinYxHcqkQUlcHeSpMC2ukzOb6lwQAfDmW+Qt0AvlGd8HpsS28qKsB+oPeJn9I39jg==}
+
   '@types/eslint-scope@3.7.7':
     resolution: {integrity: sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==}
 
@@ -3968,6 +4020,9 @@ packages:
 
   didyoumean@1.2.2:
     resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
+
+  diff-match-patch@1.0.5:
+    resolution: {integrity: sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw==}
 
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
@@ -6161,6 +6216,7 @@ packages:
   source-map@0.8.0-beta.0:
     resolution: {integrity: sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==}
     engines: {node: '>= 8'}
+    deprecated: The work that was done in this beta branch won't be included in future versions
 
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
@@ -8875,6 +8931,8 @@ snapshots:
     dependencies:
       '@types/node': 22.10.3
 
+  '@types/diff-match-patch@1.0.36': {}
+
   '@types/eslint-scope@3.7.7':
     dependencies:
       '@types/eslint': 9.6.1
@@ -10033,6 +10091,8 @@ snapshots:
       dequal: 2.0.3
 
   didyoumean@1.2.2: {}
+
+  diff-match-patch@1.0.5: {}
 
   dir-glob@3.0.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,6 @@
 packages:
   - 'packages/*'
+  - 'packages/extension-content-ai-agent'
   - 'packages-deprecated/*'
   - 'demos'
+  - 'demos/*'


### PR DESCRIPTION
## Summary
- add content AI agent extension with diff callbacks and ProseMirror plugin
- wire up React demo showcasing prompts and accept/reject diff panel
- document extension usage and link to demo in README

## Testing
- `pnpm --filter @tiptap/extension-content-ai-agent lint`
- `pnpm --filter content-ai-agent-demo lint`


------
https://chatgpt.com/codex/tasks/task_e_68b6997af700832abf3ee8917155e3b8